### PR TITLE
Fix processing of `Preview` header

### DIFF
--- a/header.go
+++ b/header.go
@@ -10,6 +10,10 @@ import (
 
 // SetPreview sets the preview bytes in the icap header
 func (r *Request) SetPreview(maxBytes int) error {
+	// do not set preview for maxBytes < 0 (-1 value is used to indicate ICAP server did not set Preview header)
+	if maxBytes < 0 {
+		return nil
+	}
 
 	bodyBytes := []byte{}
 

--- a/response.go
+++ b/response.go
@@ -23,7 +23,8 @@ type Response struct {
 func ReadResponse(b *bufio.Reader) (*Response, error) {
 
 	resp := &Response{
-		Header: make(map[string][]string),
+		Header:       make(map[string][]string),
+		PreviewBytes: -1,
 	}
 
 	scheme := ""

--- a/response_test.go
+++ b/response_test.go
@@ -2,7 +2,6 @@ package icapclient
 
 import (
 	"bufio"
-	"fmt"
 	"net/http"
 	"reflect"
 	"strings"
@@ -40,7 +39,6 @@ func checkResponseFields(sample *testSample, t *testing.T) *Response {
 		t.Fail()
 	}
 
-	fmt.Println(resp.Header)
 	for k, v := range sample.headers {
 		if val, exists := resp.Header[k]; !exists || !reflect.DeepEqual(val, v) {
 			t.Logf("Wanted Header: %s with value: %v, got: %v", k, v, val)
@@ -163,7 +161,6 @@ func TestResponse(t *testing.T) {
 
 		for _, sample := range sampleTable {
 			resp := checkResponseFields(&sample, t)
-			fmt.Println(resp)
 			if resp.ContentResponse == nil {
 				t.Log("ContentResponse is nil")
 				t.Fail()


### PR DESCRIPTION
1) Distinguish ICAP-server responses without `Preview` header from responses with  `Preview: 0`. Set value of `PreviewBytes` in response to -1 if `Preview` header was not present.
2) Filter negative values in `SetPreview`, making such requests sent with full body.