### PR TITLE
Send zero-length chunk in case of `Preview: 0`

### DIFF
--- a/consts.go
+++ b/consts.go
@@ -31,7 +31,7 @@ const (
 	CRLF                            = "\r\n"
 	DoubleCRLF                      = "\r\n\r\n"
 	LF                              = "\n"
-	bodyEndIndicator                = CRLF + "0" + DoubleCRLF
+	bodyEndIndicator                = "0" + DoubleCRLF
 	fullBodyEndIndicatorPreviewMode = "; ieof" + DoubleCRLF
 	icap100ContinueMsg              = "ICAP/1.0 100 Continue" + DoubleCRLF
 	icap204NoModsMsg                = "ICAP/1.0 204 No modifications"

--- a/parser.go
+++ b/parser.go
@@ -117,44 +117,28 @@ func addFullBodyInPreviewIndicator(str *string) {
 }
 
 // splitBodyAndHeader separates header and body from a http message
-func splitBodyAndHeader(str string) (string, string, bool) {
+func splitBodyAndHeader(str string) (headerStr string, bodyStr string) {
 	ss := strings.SplitN(str, DoubleCRLF, 2)
 
-	if len(ss) < 2 || ss[1] == "" {
-		return "", "", false
+	if len(ss) >= 1 {
+		headerStr = ss[0]
 	}
 
-	headerStr := ss[0]
-	bodyStr := ss[1]
-
-	return headerStr, bodyStr, true
+	if len(ss) == 2 {
+		bodyStr = ss[1]
+	}
+	return
 }
 
 // bodyAlreadyChunked determines if the http body is already chunked from the origin server or not
-func bodyAlreadyChunked(str string) bool {
-	_, bodyStr, ok := splitBodyAndHeader(str)
-
-	if !ok {
+func bodyAlreadyChunked(bodyStr string) bool {
+	if bodyStr == "" {
 		return false
 	}
 
 	r := regexp.MustCompile("\\r\\n0(\\r\\n)+$")
 	return r.MatchString(bodyStr)
 
-}
-
-// parsePreviewBodyBytes parses the preview portion of the body and only keeps that in the message
-func parsePreviewBodyBytes(str *string, pb int) {
-
-	headerStr, bodyStr, ok := splitBodyAndHeader(*str)
-
-	if !ok {
-		return
-	}
-
-	bodyStr = bodyStr[:pb]
-
-	*str = headerStr + DoubleCRLF + bodyStr
 }
 
 // addHexaBodyByteNotations adds the hexadecimal byte notaions in the messages
@@ -166,7 +150,11 @@ func addHexaBodyByteNotations(bodyStr *string) {
 
 	bodyBytes := []byte(*bodyStr)
 
-	*bodyStr = fmt.Sprintf("%x%s%s%s", len(bodyBytes), CRLF, *bodyStr, bodyEndIndicator)
+	if *bodyStr == "" {
+		*bodyStr = bodyEndIndicator
+		return
+	}
+	*bodyStr = fmt.Sprintf("%x%s%s%s%s", len(bodyBytes), CRLF, *bodyStr, CRLF, bodyEndIndicator)
 }
 
 // mergeHeaderAndBody merges the header and body of the http message togather

--- a/parser_test.go
+++ b/parser_test.go
@@ -194,7 +194,11 @@ func TestParser(t *testing.T) {
 		}
 
 		for _, sample := range sampleTable {
-			parsePreviewBodyBytes(&sample.httpMsg, sample.previewBytes)
+			headerStr, bodyStr := splitBodyAndHeader(sample.httpMsg)
+			if sample.previewBytes < len(bodyStr) {
+				bodyStr = bodyStr[:sample.previewBytes]
+			}
+			mergeHeaderAndBody(&sample.httpMsg, headerStr, bodyStr)
 			if sample.httpMsg != sample.result {
 				t.Logf("Wanted http message after parsing to be: %s , got: %s", sample.result, sample.httpMsg)
 				t.Fail()

--- a/request.go
+++ b/request.go
@@ -103,9 +103,10 @@ func DumpRequest(req *Request, setAbsoluteUrl bool) ([]byte, error) {
 		}
 
 		httpReqStr = string(b)
+		headerStr, bodyStr := splitBodyAndHeader(httpReqStr)
 		if setAbsoluteUrl {
-			partsHttp := strings.SplitN(httpReqStr, "\n", 2)
-			if len(partsHttp) < 2 {
+			partsHttp := strings.SplitN(headerStr, "\n", 2)
+			if len(partsHttp) < 1 {
 				return []byte{}, fmt.Errorf("Failed to parse dumped HTTPRequest: %s", httpReqStr)
 			}
 			headerLineParts := strings.Split(partsHttp[0], " ")
@@ -113,28 +114,24 @@ func DumpRequest(req *Request, setAbsoluteUrl bool) ([]byte, error) {
 				return []byte{}, fmt.Errorf("Incorrect HTTP header line: %s", partsHttp[0])
 			}
 			newHeaderLine := headerLineParts[0] + " " + req.HTTPRequest.URL.String() + " " + headerLineParts[2]
-			httpReqStr = newHeaderLine + "\n" + partsHttp[1]
+			headerStr = newHeaderLine + "\n" + partsHttp[1]
 		}
 
 		if req.Method == MethodREQMOD {
-			if req.previewSet {
-				parsePreviewBodyBytes(&httpReqStr, req.PreviewBytes)
+			if req.previewSet && req.PreviewBytes < len(bodyStr) {
+				bodyStr = bodyStr[:req.PreviewBytes]
 			}
 
-			if !bodyAlreadyChunked(httpReqStr) {
-				headerStr, bodyStr, ok := splitBodyAndHeader(httpReqStr)
-				if ok {
+			if !bodyAlreadyChunked(bodyStr) {
+				if bodyStr != "" || req.previewSet && req.PreviewBytes == 0 {
 					addHexaBodyByteNotations(&bodyStr)
-					mergeHeaderAndBody(&httpReqStr, headerStr, bodyStr)
 				}
 			}
 
 		} else { // In case of RESPMOD we send only header (see https://datatracker.ietf.org/doc/html/rfc3507#section-4.9.1)
-			headerStr, _, ok := splitBodyAndHeader(httpReqStr)
-			if ok {
-				httpReqStr = headerStr
-			}
+			bodyStr = ""
 		}
+		mergeHeaderAndBody(&httpReqStr, headerStr, bodyStr)
 
 		if httpReqStr != "" { // if the HTTP Request message block doesn't end with a \r\n\r\n, then going to add one by force for better calculation of byte offsets
 			for !strings.HasSuffix(httpReqStr, DoubleCRLF) {
@@ -155,29 +152,27 @@ func DumpRequest(req *Request, setAbsoluteUrl bool) ([]byte, error) {
 			return nil, err
 		}
 
-		httpRespStr += string(b)
+		httpRespStr = string(b)
+		headerStr, bodyStr := splitBodyAndHeader(httpRespStr)
 
-		if req.previewSet {
-			parsePreviewBodyBytes(&httpRespStr, req.PreviewBytes)
+		if req.previewSet && req.PreviewBytes < len(bodyStr) {
+			bodyStr = bodyStr[:req.PreviewBytes]
 		}
 
-		if !bodyAlreadyChunked(httpRespStr) {
-			headerStr, bodyStr, ok := splitBodyAndHeader(httpRespStr)
-			if ok {
+		if !bodyAlreadyChunked(bodyStr) {
+			if bodyStr != "" || req.previewSet && req.PreviewBytes == 0 {
 				addHexaBodyByteNotations(&bodyStr)
-				mergeHeaderAndBody(&httpRespStr, headerStr, bodyStr)
 			}
 		}
-
+		mergeHeaderAndBody(&httpRespStr, headerStr, bodyStr)
 		if httpRespStr != "" && !strings.HasSuffix(httpRespStr, DoubleCRLF) { // if the HTTP Response message block doesn't end with a \r\n\r\n, then going to add one by force for better calculation of byte offsets
 			httpRespStr = trimAllSuffixes(httpRespStr, CRLF)
 			httpRespStr += DoubleCRLF
 		}
-
 	}
 
 	if encpVal := req.Header.Get(EncapsulatedHeader); encpVal != "" {
-		reqStr = fmt.Sprintf(reqStr, encpVal)
+		reqStr = fmt.Sprintf(reqStr, encpVal) // TODO what is it for?
 	} else {
 		//populating the Encapsulated header of the ICAP message portion
 		setEncapsulatedHeaderValue(&reqStr, httpReqStr, httpRespStr)


### PR DESCRIPTION
This zero-length chunk should be sent with headers according to RFC ICAP (see https://datatracker.ietf.org/doc/html/rfc3507 page 19).

Also refactor code of `DumpRequest` a bit.